### PR TITLE
Add a cache utilization computed metric for both Redis and Memcached

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ For detailed information on this package, please refer to the [online documentat
 
 ## Release History
 
+### Version next
+
+* Add a cache utilization computed metric for both Redis and Memcached
+
 ### Version 2.3.2
 
 * Corrected the ElastiCache cache hit rate metric FQN for element details dashboard and low cache hit rate policy

--- a/analyticConfigurations/ace-elasticache.json
+++ b/analyticConfigurations/ace-elasticache.json
@@ -53,6 +53,12 @@
         "baseline" : true,
         "correlation" : true
       }
+    }, {
+      "match": "netuitive.aws.elasticache.memoryutilization",
+      "properties": {
+        "baseline": true,
+        "correlation": true
+      }
     } ]
   }
 }

--- a/analyticConfigurations/computed_metric-elasticache.json
+++ b/analyticConfigurations/computed_metric-elasticache.json
@@ -12,11 +12,18 @@
       "metricMatches" : null
     },
     "metrics" : [ {
-      "match" : "netuitive.aws.elasticache.cachehitrate",
-      "properties" : {
-        "expression" : "(data['aws.elasticache.cachehits'].actual + data['aws.elasticache.cachemisses'].actual) == 0 ? 0 : 100 * (data['aws.elasticache.cachehits'].actual / (data['aws.elasticache.cachehits'].actual + data['aws.elasticache.cachemisses'].actual))",
-        "fqn" : "netuitive.aws.elasticache.cachehitrate",
-        "name" : "Cache Hit Rate"
+      "match": "netuitive.aws.elasticache.cachehitrate",
+      "properties": {
+        "expression": "(data['aws.elasticache.cachehits'].actual + data['aws.elasticache.cachemisses'].actual) == 0 ? 0 : 100 * (data['aws.elasticache.cachehits'].actual / (data['aws.elasticache.cachehits'].actual + data['aws.elasticache.cachemisses'].actual))",
+        "fqn": "netuitive.aws.elasticache.cachehitrate",
+        "name": "Cache Hit Rate"
+      }
+    }, {
+      "match": "netuitive.aws.elasticache.utilization",
+      "properties": {
+        "expression": "100 * ((data['aws.elasticache.bytesusedforcache'].actual != undefined ? data['aws.elasticache.bytesusedforcache'].actual : data['aws.elasticache.bytesusedforcacheitems'].actual) / ((data['aws.elasticache.bytesusedforcache'].actual != undefined ? data['aws.elasticache.bytesusedforcache'].actual : data['aws.elasticache.bytesusedforcacheitems'].actual) + data['aws.elasticache.freeablememory'].actual)",
+        "fqn": "netuitive.aws.elasticache.utilization",
+        "name": "Cache Utilization"
       }
     } ]
   }

--- a/analyticConfigurations/computed_metric-elasticache.json
+++ b/analyticConfigurations/computed_metric-elasticache.json
@@ -19,11 +19,11 @@
         "name": "Cache Hit Rate"
       }
     }, {
-      "match": "netuitive.aws.elasticache.utilization",
+      "match": "netuitive.aws.elasticache.memoryutilization",
       "properties": {
         "expression": "100 * ((data['aws.elasticache.bytesusedforcache'].actual != undefined ? data['aws.elasticache.bytesusedforcache'].actual : data['aws.elasticache.bytesusedforcacheitems'].actual) / ((data['aws.elasticache.bytesusedforcache'].actual != undefined ? data['aws.elasticache.bytesusedforcache'].actual : data['aws.elasticache.bytesusedforcacheitems'].actual) + data['aws.elasticache.freeablememory'].actual)",
-        "fqn": "netuitive.aws.elasticache.utilization",
-        "name": "Cache Utilization"
+        "fqn": "netuitive.aws.elasticache.memoryutilization",
+        "name": "Cache Memory Utilization"
       }
     } ]
   }

--- a/analyticConfigurations/metric_meta-elasticache.json
+++ b/analyticConfigurations/metric_meta-elasticache.json
@@ -71,12 +71,22 @@
         }
       }
     }, {
-      "match" : "netuitive.aws.elasticache.cachehitrate",
-      "properties" : {
-        "tags" : {
-          "unit" : "percent"
+      "match": "netuitive.aws.elasticache.cachehitrate",
+      "properties": {
+        "tags": {
+          "unit": "percent"
         },
-        "validMax" : "100"
+        "validMax": "100"
+      }
+    }, {
+      "match": "netuitive.aws.elasticache.utilization",
+      "properties": {
+        "tags": {
+          "unit": "percent",
+          "utilization": true
+        },
+        "validMin": "0",
+        "validMax": "100"
       }
     } ]
   }

--- a/analyticConfigurations/metric_meta-elasticache.json
+++ b/analyticConfigurations/metric_meta-elasticache.json
@@ -79,7 +79,7 @@
         "validMax": "100"
       }
     }, {
-      "match": "netuitive.aws.elasticache.utilization",
+      "match": "netuitive.aws.elasticache.memoryutilization",
       "properties": {
         "tags": {
           "unit": "percent",


### PR DESCRIPTION
The "cache used bytes" metric is different for Redis and Memcached so this computed metric checks for the existence of one metric before using the other in both portions of the calculation.

Closes #18