### PR TITLE
Fixes #20 - Corrected number format in policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ For detailed information on this package, please refer to the [online documentat
 ### Version next
 
 * Add a cache utilization computed metric for both Redis and Memcached
+* Fixed number format in AWS ElastiCache Memcached - Elevated Swap Usage to stop breaking the package validators
 
 ### Version 2.3.2
 

--- a/policies/aws.elasticache.memcached.-.elevated.swap.usage.json
+++ b/policies/aws.elasticache.memcached.-.elevated.swap.usage.json
@@ -18,7 +18,7 @@
       "metricScopeTags" : { },
       "analytic" : "actual",
       "operator" : ">",
-      "level" : 5.24288E7,
+      "level" : 52428800,
       "level2" : null,
       "metricThresholdLevel" : null,
       "metricThresholdAnalytic" : null


### PR DESCRIPTION
Corrrected the number format in the AWS ElastiCache Memcached - Elevated
Swap Usage policy so json validators wouldn't choke on the number given
in scientific notation.