### PR TITLE
Add a missing close parens on the memoryutilization computed metric

### DIFF
--- a/analyticConfigurations/computed_metric-elasticache.json
+++ b/analyticConfigurations/computed_metric-elasticache.json
@@ -21,7 +21,7 @@
     }, {
       "match": "netuitive.aws.elasticache.memoryutilization",
       "properties": {
-        "expression": "100 * ((data['aws.elasticache.bytesusedforcache'].actual != undefined ? data['aws.elasticache.bytesusedforcache'].actual : data['aws.elasticache.bytesusedforcacheitems'].actual) / ((data['aws.elasticache.bytesusedforcache'].actual != undefined ? data['aws.elasticache.bytesusedforcache'].actual : data['aws.elasticache.bytesusedforcacheitems'].actual) + data['aws.elasticache.freeablememory'].actual)",
+        "expression": "100 * ((data['aws.elasticache.bytesusedforcache'].actual != undefined ? data['aws.elasticache.bytesusedforcache'].actual : data['aws.elasticache.bytesusedforcacheitems'].actual) / ((data['aws.elasticache.bytesusedforcache'].actual != undefined ? data['aws.elasticache.bytesusedforcache'].actual : data['aws.elasticache.bytesusedforcacheitems'].actual) + data['aws.elasticache.freeablememory'].actual))",
         "fqn": "netuitive.aws.elasticache.memoryutilization",
         "name": "Cache Memory Utilization"
       }


### PR DESCRIPTION
I left off a Readme comment because this is a fix to an unreleased feature.